### PR TITLE
fix: weird crash

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Basalt (Time, Time Steel)",
+            "type": "pebble",
+            "request": "launch",
+            "platform": "basalt",
+            "elfPath": "${workspaceFolder}/build/basalt/pebble-app.elf",
+            "workDir": "${workspaceFolder}/"
+        },
+    ]
+}

--- a/src/simply/simply_window.c
+++ b/src/simply/simply_window.c
@@ -140,6 +140,24 @@ static void prv_update_layer_placement(SimplyWindow *self, GRect *frame_out) {
     }
   }
 
+  if (frame.size.w <= 0 || frame.size.h <= 0) {
+    APP_LOG(APP_LOG_LEVEL_ERROR, "Invalid frame size: width = %d, height = %d", frame.size.w, frame.size.h);
+    return;
+  }
+
+  // check origin size
+  if (frame.origin.x <= 0 && frame.origin.y <= 0) {
+    APP_LOG(APP_LOG_LEVEL_ERROR, "Invalid frame origin: x = %d, y = %d", frame.origin.x, frame.origin.y);
+    return;
+  }
+
+  if (!main_layer) {
+    APP_LOG(APP_LOG_LEVEL_ERROR, "Main layer is NULL");
+    return;
+  }
+  
+  
+
   layer_set_frame(main_layer, frame);
   if (frame_out) {
     *frame_out = frame;


### PR DESCRIPTION
This PR fixes the weird "backing out of light detail crashes the app" bug. It was because Pebble.js for some reason likes to either:
- set frames with a zero/negative **X** origin (crashes the app)
  - Having no/negative Y origin is an actual thing*. X origin is not and crashes the app.
  - *unless the X origin is too, then the app crashes. If the X origin is set, and the Y origin is not set (0), it works fine.
- set frames with a zero/negative target (crashes the app)
- fails to get the main window for whatever reason, sets a frame on the `NULL` main window, crashing the app.

This PR adds error checking to all of these. 

However, it appears, even when in an error state, nothing changes. Everything still works. It's possible this `layer_set_frame` isn't even required.